### PR TITLE
Documentation of Polymorphic Eta-Expansion

### DIFF
--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -1818,8 +1818,8 @@ eta-expanded to:
 
 
 In the case where the expected type is not polymorphic, or the clauses are 
-incompatible then fresh type variables are inserted, they will either be 
-replaced by a concrete type or throw a typing error, for example with our 
+incompatible, then fresh type variables are inserted. They will either be 
+replaced by a concrete type or throw a typing error. For example with our 
 previous `ident`:
 
 ```scala

--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -1805,7 +1805,7 @@ them to the method. The bounds are those of the expected type if present
 the bounds are the method's bounds. The result of eta-expansion is then:
 
 ```scala
-[´Fresh_1 , \ldots , Fresh_n´] => ´e´[´Fresh_1 , \ldots , Fresh_n´]
+[´T_1 <: U_1 >: L_1, \ldots , T_n <: U_n >: L_n´] => ´e´[´T_1 , \ldots , T_n´]
 ```
 
 Note that the compatibility of the subexpression and the expected 


### PR DESCRIPTION
This edits the scala 2 specification to document the changes that will be added by [Polymorphic Eta-Expansion](https://github.com/lampepfl/dotty/pull/14015)
It is not designed to be merged with the scala 2 specification as those changes target scala 3,
But to instead document those changes, and allow an easier generation of the scala 3 docs when the time comes.

Please refer to the other PR for any remarks/questions/suggestions not linked with the documentation.