### PR TITLE
Documentation of Interweaved Clauses

### DIFF
--- a/spec/03-types.md
+++ b/spec/03-types.md
@@ -190,6 +190,7 @@ with a type member `Node` and the standard class `scala.Int`,
 SimpleType      ::=  SimpleType TypeArgs
 TypeArgs        ::=  ‘[’ Types ‘]’
 ```
+<!-- TODO: if currying is added for Parametrised types, change here -->
 
 A _parameterized type_ ´T[ T_1 , \ldots , T_n ]´ consists of a type
 designator ´T´ and type parameters ´T_1 , \ldots , T_n´ where
@@ -587,6 +588,7 @@ do they appear explicitly in programs. They are introduced in this
 report as the internal types of defined identifiers.
 
 ### Method Types
+<!-- TODO: Update with new internal representation for interweaving -->
 
 A _method type_ is denoted internally as ´(\mathit{Ps})U´, where ´(\mathit{Ps})´
 is a sequence of parameter names and types ´(p_1:T_1 , \ldots , p_n:T_n)´
@@ -626,6 +628,7 @@ c: (Int) (String, String) String
 ```
 
 ### Polymorphic Method Types
+<!-- TODO: Update with new internal representation for interweaving -->
 
 A polymorphic method type is denoted internally as `[´\mathit{tps}\,´]´T´` where
 `[´\mathit{tps}\,´]` is a type parameter section

--- a/spec/04-basic-declarations-and-definitions.md
+++ b/spec/04-basic-declarations-and-definitions.md
@@ -626,17 +626,18 @@ A _value parameter clause_ ´\mathit{ps}´ consists of zero or more formal
 parameter bindings such as `´x´: ´T´` or `´x: T = e´`, which bind value
 parameters and associate them with their types.
 
-<!-- TODO: check following: -->
 Note that parameter names have to be unique not only inside clauses but between them too.
 Note that parameters inside type and term clauses are allowed to depend on 
-parameters of the previous ones, the following example is valid:
+parameters of the previous ones.
+
+###### Example
 ```scala
-def foo[T](x: T)[U :> x.type <: T][L <: List[U]](l: L) // valid
-def bar[T](x: T)[T] // invalid: T appears twice
-def zoo(x: Int)[T, U](x: U) // invalid: x appears twice
-def aaa(T <: U)(x: U)[U] //invalid: U appears after being used
+def foo[T](x: T)[U >: x.type <: T][L <: List[U]](l: L): L // valid
+def bar[T](x: T)[T]: String // invalid: T appears twice
+def zoo(x: Int)[T, U](x: U): T // invalid: x appears twice
+def aaa(x: U): U // valid if U is in scope
+def bbb[T <: U](x: U)[U]: U //valid if U is in scope, same as aaa
 ```
-<!-- TODO: in the case of the last example, should it be valid if a definition for U is in scope ? -->
 
 ### Default Arguments
 

--- a/spec/05-classes-and-objects.md
+++ b/spec/05-classes-and-objects.md
@@ -151,6 +151,7 @@ def delayedInit(body: => Unit): Unit
 ```ebnf
 Constr  ::=  AnnotType {‘(’ [Exprs] ‘)’}
 ```
+<!-- TODO: if add constructor with interweaving, change this -->
 
 Constructor invocations define the type, members, and initial state of
 objects created by an instance creation expression, or of parts of an
@@ -690,7 +691,7 @@ ClassParam        ::=  {Annotation} {Modifier} [(‘val’ | ‘var’)]
                        id [‘:’ ParamType] [‘=’ Expr]
 ClassTemplateOpt  ::=  ‘extends’ ClassTemplate | [[‘extends’] TemplateBody]
 ```
-
+<!-- TODO: if update class params, change here-->
 The most general form of class definition is
 
 ```scala

--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -473,7 +473,7 @@ for a polymorphic method from the types of the actual method arguments
 and the expected result type.
 
 In the case of a function with multiple lists of type arguments, and/or 
-which returns a value with a higher kinded type, the applied types are the leftmost
+which returns a value with a polymorphic function type, the applied types are the leftmost
 ones, while the rightmost ones are inferred.
 
 ###### example

--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -472,6 +472,52 @@ Type applications can be omitted if
 for a polymorphic method from the types of the actual method arguments
 and the expected result type.
 
+Remember that functions can have multiple lists of type arguments, and/or 
+return a value with a higher kinded type, as a simple example, 
+take the two following declarations, where ´Z´ is an arbitrary type, 
+potentially containing references to ´T´ and ´U´:
+
+```scala
+def foo[T][U]: Z
+def bar[T]: [U] -> Z
+```
+
+At application, we can then homit either ´T´ and ´U´ or neither, 
+or we can homit ´U´ but not ´T´. 
+But if a parameter for ´U´ is passed, then one must be as well for ´T´, 
+even if the value passed make sense for ´U´ but not for ´T´, 
+as in the following example:
+```scala
+def foo[T <: Int][U <: String]: Z
+
+foo[Int][String] // valid
+foo[Int] // valid* 
+foo // valid*
+
+foo[String] // invalid!
+
+// * if remaining values can be implied
+```
+If there is need to be able to specify any combination, 
+use an empty term clause like this:
+```scala
+def foo[T <: Int]()[U <: String]: Z
+
+foo[Int]()[String] // valid
+foo[Int]() // valid* 
+foo() // valid*
+
+foo()[String] // valid*
+
+//but of course:
+foo[Int][String] // invalid: expected 1 type clause, but got 2
+
+// * if remaining values can be implied
+```
+In most cases this should not be needed, and might hint at your 
+implementation separating too much type clauses from the term clauses
+that reference those types.
+
 ## Tuples
 
 ```ebnf

--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -472,21 +472,14 @@ Type applications can be omitted if
 for a polymorphic method from the types of the actual method arguments
 and the expected result type.
 
-Remember that functions can have multiple lists of type arguments, and/or 
-return a value with a higher kinded type, as a simple example, 
-take the two following declarations, where ´Z´ is an arbitrary type, 
+In the case of a function with multiple lists of type arguments, and/or 
+which returns a value with a higher kinded type, the applied types are the leftmost
+ones, while the rightmost ones are inferred.
+
+###### example
+Where ´Z´ is an arbitrary type, 
 potentially containing references to ´T´ and ´U´:
 
-```scala
-def foo[T][U]: Z
-def bar[T]: [U] -> Z
-```
-
-At application, we can then homit either ´T´ and ´U´ or neither, 
-or we can homit ´U´ but not ´T´. 
-But if a parameter for ´U´ is passed, then one must be as well for ´T´, 
-even if the value passed make sense for ´U´ but not for ´T´, 
-as in the following example:
 ```scala
 def foo[T <: Int][U <: String]: Z
 
@@ -496,10 +489,12 @@ foo // valid*
 
 foo[String] // invalid!
 
-// * if remaining values can be implied
+// * if remaining types can be inferred
 ```
+<!-- TODO: Shelve this ? -->
 If there is need to be able to specify any combination, 
-use an empty term clause like this:
+an empty term clause can be used:
+
 ```scala
 def foo[T <: Int]()[U <: String]: Z
 
@@ -512,10 +507,11 @@ foo()[String] // valid*
 //but of course:
 foo[Int][String] // invalid: expected 1 type clause, but got 2
 
-// * if remaining values can be implied
+// * if remaining types can be inferred
 ```
-In most cases this should not be needed, and might hint at your 
-implementation separating too much type clauses from the term clauses
+
+In most cases this should not be needed, and might hint at 
+type clauses being separated too much from the term clauses
 that reference those types.
 
 ## Tuples
@@ -1820,7 +1816,7 @@ a = scala.Any
 so `scala.Any` is the type inferred for `a`.
 
 ### <a name="eta-expansion-section">Eta Expansion</a>
-
+<!-- TODO: Update with type lambdas for Polymorphic methods -->
 _Eta-expansion_ converts an expression of method type to an
 equivalent expression of function type. It proceeds in two steps.
 

--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -1816,7 +1816,7 @@ a = scala.Any
 so `scala.Any` is the type inferred for `a`.
 
 ### <a name="eta-expansion-section">Eta Expansion</a>
-<!-- TODO: Update with type lambdas for Polymorphic methods -->
+
 _Eta-expansion_ converts an expression of method type to an
 equivalent expression of function type. It proceeds in two steps.
 
@@ -1839,6 +1839,29 @@ n´). The result of eta-conversion is then:
 The behavior of [call-by-name parameters](#function-applications)
 is preserved under eta-expansion: the corresponding actual argument expression,
 a sub-expression of parameterless method type, is not evaluated in the expanded block.
+
+In the case of a polymorphic method, the type arguments are set 
+according to the expected type, if they are not constrained, they are replaced by their upper bound,
+even in cases where the expected type is polymorphic, leading to a typing error.
+(This might however change in future versions of scala 3)
+
+###### Examples
+
+```scala
+def id[T](x: T) = x // method type [T](T)T
+
+val valId1 /*Any => Any*/ = id
+val valId2:  Int => Int   = id
+val valId3: [T] => T => T = id // error: Found: Any => Any, Required: [T] => T => T
+
+def requestInt2Int(f: Int => Int) = ???
+
+requestInt2Int(id)
+requestInt2Int(valId1) // error: Found: Any => Any, Required: Int => Int
+requestInt2Int(valId2)
+requestInt2Int(valId3) // error: Found: [T] => T => T, Required: Int => Int // Why doesn't infer ?
+requestInt2Int(valId3[Int])
+```
 
 ### Dynamic Member Selection
 


### PR DESCRIPTION
This edits the scala 2 specification to document the changes that will be added by [Adding Interweaved Clauses](https://github.com/lampepfl/dotty/pull/14019)
It is not designed to be merged with the scala 2 specification as those changes target scala 3,
But to instead document those changes, and allow an easier generation of the scala 3 docs when the time comes.

Please refer to the other PR for any remarks/questions/suggestions not linked with the documentation.